### PR TITLE
Fix min value for linear and log scales

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -200,7 +200,7 @@ const Index: NextPage<KoronaData> = ({ confirmed, deaths, recovered }) => {
   );
   const dataMinValue =
     Math.min(minValues.deaths, minValues.infections, minValues.infections) ||
-    cumulativeChartScale === 'log'  // logarithmic scale can't handle zero values
+    cumulativeChartScale === 'log' // logarithmic scale can't handle zero values
       ? 1
       : 0;
 
@@ -306,7 +306,8 @@ const Index: NextPage<KoronaData> = ({ confirmed, deaths, recovered }) => {
               )}`}
               footer={`${t(
                 'latest case'
-              )} ${latestInfection} (${latestInfectionDistrict ?? t('unknown')})`}
+              )} ${latestInfection} (${latestInfectionDistrict ??
+                t('unknown')})`}
             >
               <StatBlock
                 count={confirmed.length}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -192,17 +192,11 @@ const Index: NextPage<KoronaData> = ({ confirmed, deaths, recovered }) => {
   );
   const maxValues =
     infectionDevelopmentData30Days[infectionDevelopmentData30Days.length - 1];
-  const minValues = infectionDevelopmentData30Days[0];
   const dataMaxValue = Math.max(
     maxValues.deaths,
     maxValues.infections,
     maxValues.infections
   );
-  const dataMinValue =
-    Math.min(minValues.deaths, minValues.infections, minValues.infections) ||
-    cumulativeChartScale === 'log' // logarithmic scale can't handle zero values
-      ? 1
-      : 0;
 
   const {
     infectionsByDistrict,
@@ -480,7 +474,7 @@ const Index: NextPage<KoronaData> = ({ confirmed, deaths, recovered }) => {
                   <YAxis
                     scale={cumulativeChartScale}
                     dataKey="infections"
-                    domain={[dataMinValue, dataMaxValue + 10]}
+                    domain={[cumulativeChartScale === 'log' ? 1 : 0, dataMaxValue + 10]}
                     unit={' ' + t('person')}
                     tick={{ fontSize: 12 }}
                     name={t('cases')}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -198,11 +198,11 @@ const Index: NextPage<KoronaData> = ({ confirmed, deaths, recovered }) => {
     maxValues.infections,
     maxValues.infections
   );
-  const dataMinValue = Math.min(
-    minValues.deaths || 1,
-    minValues.infections || 1,
-    minValues.infections || 1
-  );
+  const dataMinValue =
+    Math.min(minValues.deaths, minValues.infections, minValues.infections) ||
+    cumulativeChartScale === 'log'  // logarithmic scale can't handle zero values
+      ? 1
+      : 0;
 
   const {
     infectionsByDistrict,

--- a/utils/translation.ts
+++ b/utils/translation.ts
@@ -50,7 +50,7 @@ const phrases: { [key: string]: { [key: string]: string } } = {
     infectionNetwork: 'Tartuntaverkosto',
     infectionNetworkFooter:
       'Kuvio esittää tartunnat verkostona. Numero on tartunnan järjestysnumero. Mikäli suoraa tartuttajaa ei tiedetä linkitetään tartunta alkuperämaahan. Kuvasta on jätetty pois tartunnat joiden suoraa aiheuttajaa tai alkuperämaata ei ole tiedossa. Suomeen merkatut tartunnat liittyvät suurella todennäköisyydellä muihin tartuntaverkostoihin. Solun väri kertoo maan jossa tartunta on todennäköisesti tapahtunut.',
-    'unknown': 'tuntematon'
+    unknown: 'tuntematon'
   },
   en: {
     language: 'English',
@@ -99,7 +99,7 @@ const phrases: { [key: string]: { [key: string]: string } } = {
     infectionNetwork: 'Infection network graph',
     infectionNetworkFooter:
       'Number is the id of the case. Cases withouth origin are left out.',
-    'unknown': 'unknown'
+    unknown: 'unknown'
   },
   fa: {
     language: 'فارسی',
@@ -145,7 +145,7 @@ const phrases: { [key: string]: { [key: string]: string } } = {
     infectionNetwork: 'Infection network graph',
     infectionNetworkFooter:
       'Number is the id of the case. Cases withouth origin are left out.',
-    'unknown': 'ناشناخته'
+    unknown: 'ناشناخته'
   }
 };
 


### PR DESCRIPTION
Ennen:

<img width="1467" alt="Screenshot 2020-03-21 at 23 19 13" src="https://user-images.githubusercontent.com/2647016/77236786-6c22b080-6bca-11ea-8ae0-dfba5d4ba8ce.png">

Jälkeen:
<img width="1423" alt="Screenshot 2020-03-21 at 23 19 51" src="https://user-images.githubusercontent.com/2647016/77236792-793f9f80-6bca-11ea-835b-238b53061748.png">

Lineaarinen skaala voi alkaa nollasta, logaritminen ei (log(0) ongelma), joten parempi aloittaa yhdestä.

E: Muutin minimiarvon aina olemaan joko 0 tai 1 riippuen onko skaala lineaarinen vai logaritminen. Simppelimpi näin.