### PR TITLE
Sovella sairaanhoitopiirivalinta kaikkiin numeroihin ja graafeihin

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -200,7 +200,7 @@ const Index: NextPage<KoronaData> = ({ confirmed, deaths, recovered }) => {
   );
   const dataMinValue =
     Math.min(minValues.deaths, minValues.infections, minValues.infections) ||
-    cumulativeChartScale === 'log'  // logarithmic scale can't handle zero values
+    cumulativeChartScale === 'log' // logarithmic scale can't handle zero values
       ? 1
       : 0;
 
@@ -306,7 +306,8 @@ const Index: NextPage<KoronaData> = ({ confirmed, deaths, recovered }) => {
               )}`}
               footer={`${t(
                 'latest case'
-              )} ${latestInfection} (${latestInfectionDistrict ?? t('unknown')})`}
+              )} ${latestInfection} (${latestInfectionDistrict ??
+                t('unknown')})`}
             >
               <StatBlock
                 count={confirmed.length}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -218,7 +218,7 @@ const Index: NextPage<KoronaData> = ({
     if (district === 'all') {
       return t('All healthcare districts');
     } else if (district === 'unknown') {
-      return t('Unknown');
+      return t('unknown');
     } else {
       return district;
     }
@@ -322,7 +322,7 @@ const Index: NextPage<KoronaData> = ({
                 {t('All healthcare districts')}
               </option>
               <option key={'unknown'} value={'unknown'}>
-                {t('Unknown')}
+                {t('unknown')}
               </option>
               {healtCareDistricts.map(healthcareDistrict => (
                 <option

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -190,12 +190,11 @@ const Index: NextPage<KoronaData> = ({
   const {
     infectionDevelopmentData,
     infectionDevelopmentData30Days
-  } = getTimeSeriesData(confirmed, recovered, deaths, districtFilter);
+  } = getTimeSeriesData(confirmed, recovered, deaths);
   const { prediction60Days, today } = getPredictionData(
     confirmed,
     deaths,
-    recovered,
-    districtFilter
+    recovered
   );
   const maxValues =
     infectionDevelopmentData30Days[infectionDevelopmentData30Days.length - 1];
@@ -299,22 +298,21 @@ const Index: NextPage<KoronaData> = ({
           width={'100%'}
         >
           <Box width={['100%', '100%', 1 / 3, 1 / 3]} p={3}>
-              <Select
-                placeholder={t('healthcare district')}
-                value={selectedHealthCareDistrict ?? undefined}
-                onChange={event => selectHealthCareDistrict(event.target.value)}
-              >
-                {healtCareDistricts.map(healthcareDistrict => (
-                  <option
-                    key={healthcareDistrict.name}
-                    value={healthcareDistrict.name}
-                  >
-                    {healthcareDistrict.name}
-                  </option>
-                ))}
-              </Select>
+            <Select
+              placeholder={t('healthcare district')}
+              value={selectedHealthCareDistrict ?? undefined}
+              onChange={event => selectHealthCareDistrict(event.target.value)}
+            >
+              {healtCareDistricts.map(healthcareDistrict => (
+                <option
+                  key={healthcareDistrict.name}
+                  value={healthcareDistrict.name}
+                >
+                  {healthcareDistrict.name}
+                </option>
+              ))}
+            </Select>
           </Box>
-
         </Flex>
         <Flex
           flexWrap="wrap"

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -192,17 +192,11 @@ const Index: NextPage<KoronaData> = ({ confirmed, deaths, recovered }) => {
   );
   const maxValues =
     infectionDevelopmentData30Days[infectionDevelopmentData30Days.length - 1];
-  const minValues = infectionDevelopmentData30Days[0];
   const dataMaxValue = Math.max(
     maxValues.deaths,
     maxValues.infections,
     maxValues.infections
   );
-  const dataMinValue =
-    Math.min(minValues.deaths, minValues.infections, minValues.infections) ||
-    cumulativeChartScale === 'log' // logarithmic scale can't handle zero values
-      ? 1
-      : 0;
 
   const {
     infectionsByDistrict,
@@ -480,7 +474,7 @@ const Index: NextPage<KoronaData> = ({ confirmed, deaths, recovered }) => {
                   <YAxis
                     scale={cumulativeChartScale}
                     dataKey="infections"
-                    domain={[dataMinValue, dataMaxValue + 10]}
+                    domain={[cumulativeChartScale === 'log' ? 1 : 0, dataMaxValue + 10]}
                     unit={' ' + t('person')}
                     tick={{ fontSize: 12 }}
                     name={t('cases')}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -211,9 +211,6 @@ const Index: NextPage<KoronaData> = ({
   } = getTnfectionsByDistrict(allConfirmed);
   const { infectionsBySourceCountry } = getInfectionsBySourceCountry(confirmed);
   const networkGraphData = getNetworkGraphData(confirmed);
-  const reversedConfirmed = confirmed
-    .map((i, index) => ({ index: index + 1, ...i }))
-    .reverse();
 
   const { t } = useContext(UserContext);
 
@@ -226,6 +223,10 @@ const Index: NextPage<KoronaData> = ({
       return district;
     }
   };
+
+  const reversedConfirmed = confirmed
+    .map((i, index) => ({ index: index + 1, ...i, healthCareDistrict: humanizeHealthcareDistrict(i.healthCareDistrict) }))
+    .reverse();
 
   const humanizedHealthCareDistrict = humanizeHealthcareDistrict(
     selectedHealthCareDistrict
@@ -352,8 +353,7 @@ const Index: NextPage<KoronaData> = ({
               )}`}
               footer={`${t(
                 'latest case'
-              )} ${latestInfection} (${latestInfectionDistrict ??
-                t('unknown')})`}
+              )} ${latestInfection} (${humanizeHealthcareDistrict(latestInfectionDistrict)})`}
             >
               <StatBlock
                 count={confirmed.length}
@@ -368,7 +368,7 @@ const Index: NextPage<KoronaData> = ({
               title={t('deaths') + ` (${humanizedHealthCareDistrict})`}
               footer={
                 latestDeath
-                  ? `${t('last death')} ${latestDeath} (${latestDeathDistrict})`
+                  ? `${t('last death')} ${latestDeath} (${humanizeHealthcareDistrict(latestDeathDistrict!)})`
                   : t('no death')
               }
             >
@@ -382,7 +382,7 @@ const Index: NextPage<KoronaData> = ({
                 latestRecovered
                   ? `${t(
                       'latest recovery'
-                    )} ${latestRecovered} (${latestRecoveredDistrict})`
+                    )} ${latestRecovered} (${humanizeHealthcareDistrict(latestRecoveredDistrict!)})`
                   : ' '
               }
             >
@@ -764,7 +764,7 @@ Index.getInitialProps = async function() {
     infectionSourceCountry:
       i.infectionSourceCountry === '' ? null : i.infectionSourceCountry,
     healthCareDistrict:
-      i.healthCareDistrict === '' ? 'unknown' : i.healthCareDistrict
+      i.healthCareDistrict ? i.healthCareDistrict : 'unknown' // there are empty strings and nulls
   }));
   return { ...data, confirmed };
 };

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -324,7 +324,7 @@ const Index: NextPage<KoronaData> = ({
         >
           <Box width={['100%', '100%', 1 / 3, 1 / 3]} p={3}>
             <Block
-              title={t('cases')}
+              title={t('cases') + ` (${selectedHealthCareDistrict})`}
               textAlign="center"
               extraInfo={`${t('New cases today')} ${infectionsToday} ${t(
                 'person'
@@ -344,7 +344,7 @@ const Index: NextPage<KoronaData> = ({
           </Box>
           <Box width={['100%', '100%', 1 / 3, 1 / 3]} p={3}>
             <Block
-              title={t('deaths')}
+              title={t('deaths') + ` (${selectedHealthCareDistrict})`}
               footer={
                 latestDeath
                   ? `${t('last death')} ${latestDeath} (${latestDeathDistrict})`
@@ -356,7 +356,7 @@ const Index: NextPage<KoronaData> = ({
           </Box>
           <Box width={['100%', '100%', 1 / 3, 1 / 3]} p={3}>
             <Block
-              title={t('recovered')}
+              title={t('recovered') + ` (${selectedHealthCareDistrict})`}
               footer={
                 latestRecovered
                   ? `${t(
@@ -371,7 +371,7 @@ const Index: NextPage<KoronaData> = ({
 
           <Box width={['100%']} p={3}>
             <Block
-              title={t('accumulated change')}
+              title={t('accumulated change')  + ` (${selectedHealthCareDistrict})`}
               footer={t('cases recovered and death in past 30 days')}
             >
               <ButtonGroup
@@ -660,7 +660,7 @@ const Index: NextPage<KoronaData> = ({
           </Box>
           <Box width={['100%', '100%', '100%', '100%', 1 / 2]} p={3}>
             <Block
-              title={t('Origin country of the cases')}
+              title={t('Origin country of the cases') + ` (${selectedHealthCareDistrict})`}
               footer={t('originCountryFooter')}
             >
               <ResponsiveContainer width={'100%'} height={350}>
@@ -699,7 +699,7 @@ const Index: NextPage<KoronaData> = ({
             </Block>
           </Box>
           <Box width={['100%', '100%', '100%', '100%', 1 / 2]} p={3}>
-            <Block title={t('log')} footer={t('logFooter')}>
+            <Block title={t('log') + ` (${selectedHealthCareDistrict})`} footer={t('logFooter')}>
               <Table
                 height={350}
                 data={reversedConfirmed}
@@ -709,7 +709,7 @@ const Index: NextPage<KoronaData> = ({
           </Box>
           <Box width={['100%']} p={3}>
             <Block
-              title={t('infectionNetwork')}
+              title={t('infectionNetwork') + ` (${selectedHealthCareDistrict})`}
               footer={t('infectionNetworkFooter')}
             >
               <NetworkGraph data={networkGraphData} />

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -198,11 +198,11 @@ const Index: NextPage<KoronaData> = ({ confirmed, deaths, recovered }) => {
     maxValues.infections,
     maxValues.infections
   );
-  const dataMinValue = Math.min(
-    minValues.deaths || 1,
-    minValues.infections || 1,
-    minValues.infections || 1
-  );
+  const dataMinValue =
+    Math.min(minValues.deaths, minValues.infections, minValues.infections) ||
+    cumulativeChartScale === 'log'  // logarithmic scale can't handle zero values
+      ? 1
+      : 0;
 
   const {
     infectionsByDistrict,

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -133,7 +133,21 @@ const ConditionallyRender: React.FC<ConditionallyRenderProps> = props => {
   return props.children as React.ReactElement;
 };
 
-const Index: NextPage<KoronaData> = ({ confirmed, deaths, recovered }) => {
+const Index: NextPage<KoronaData> = ({
+  confirmed: allConfirmed,
+  deaths: allDeaths,
+  recovered: allRecovered
+}) => {
+  const [selectedHealthCareDistrict, selectHealthCareDistrict] = useState<
+    string | null
+  >(null);
+  const districtFilter = (item: BaseItem) =>
+    selectedHealthCareDistrict
+      ? item.healthCareDistrict === selectedHealthCareDistrict
+      : true;
+  const confirmed = allConfirmed.filter(districtFilter);
+  const deaths = allDeaths.filter(districtFilter);
+  const recovered = allRecovered.filter(districtFilter);
   // Map some data for stats blocks
   const date = new Date('2018-09-01Z16:01:36.386Z');
   const latestInfection = format(
@@ -169,16 +183,9 @@ const Index: NextPage<KoronaData> = ({ confirmed, deaths, recovered }) => {
   const [cumulativeChartScale, setCumulativeChartScale] = useState<
     'linear' | 'log'
   >('linear');
-  const [selectedHealthCareDistrict, selectHealthCareDistrict] = useState<
-    string | null
-  >(null);
   const [forecastChartScale, setForecaseChartScale] = useState<
     'linear' | 'log'
   >('linear');
-  const districtFilter = (item: BaseItem) =>
-    selectedHealthCareDistrict
-      ? item.healthCareDistrict === selectedHealthCareDistrict
-      : true;
   // Map data to show development of infections
   const {
     infectionDevelopmentData,
@@ -202,7 +209,7 @@ const Index: NextPage<KoronaData> = ({ confirmed, deaths, recovered }) => {
     infectionsByDistrict,
     infectionsByDistrictPercentage,
     areas
-  } = getTnfectionsByDistrict(confirmed);
+  } = getTnfectionsByDistrict(allConfirmed);
   const { infectionsBySourceCountry } = getInfectionsBySourceCountry(confirmed);
   const networkGraphData = getNetworkGraphData(confirmed);
   const reversedConfirmed = confirmed
@@ -286,6 +293,32 @@ const Index: NextPage<KoronaData> = ({ confirmed, deaths, recovered }) => {
         <Flex
           flexWrap="wrap"
           flexDirection="row"
+          justifyContent="left"
+          alignItems="stretch"
+          flex="1"
+          width={'100%'}
+        >
+          <Box width={['100%', '100%', 1 / 3, 1 / 3]} p={3}>
+              <Select
+                placeholder={t('healthcare district')}
+                value={selectedHealthCareDistrict ?? undefined}
+                onChange={event => selectHealthCareDistrict(event.target.value)}
+              >
+                {healtCareDistricts.map(healthcareDistrict => (
+                  <option
+                    key={healthcareDistrict.name}
+                    value={healthcareDistrict.name}
+                  >
+                    {healthcareDistrict.name}
+                  </option>
+                ))}
+              </Select>
+          </Box>
+
+        </Flex>
+        <Flex
+          flexWrap="wrap"
+          flexDirection="row"
           justifyContent="center"
           alignItems="stretch"
           flex="1"
@@ -343,61 +376,38 @@ const Index: NextPage<KoronaData> = ({ confirmed, deaths, recovered }) => {
               title={t('accumulated change')}
               footer={t('cases recovered and death in past 30 days')}
             >
-              <Flex justify="space-between" mr={4} ml={4} mt={0} mb={0}>
-                <Flex>
-                  <Select
-                    placeholder={t('healthcare district')}
-                    value={selectedHealthCareDistrict ?? undefined}
-                    onChange={event =>
-                      selectHealthCareDistrict(event.target.value)
-                    }
-                  >
-                    {healtCareDistricts.map(healthcareDistrict => (
-                      <option
-                        key={healthcareDistrict.name}
-                        value={healthcareDistrict.name}
-                      >
-                        {healthcareDistrict.name}
-                      </option>
-                    ))}
-                  </Select>
-                </Flex>
-                <Flex>
-                  <ButtonGroup
-                    spacing={0}
-                    alignSelf="center"
-                    display="flex"
-                    justifyContent="center"
-                    marginTop="-15px"
-                  >
-                    <Button
-                      size="xs"
-                      fontFamily="Space Grotesk Regular"
-                      px={3}
-                      letterSpacing="1px"
-                      borderRadius="4px 0px 0px 4px"
-                      borderWidth="0px"
-                      isActive={cumulativeChartScale === 'linear'}
-                      onClick={() => setCumulativeChartScale('linear')}
-                    >
-                      {t('linear')}
-                    </Button>
-                    <Button
-                      size="xs"
-                      fontFamily="Space Grotesk Regular"
-                      px={3}
-                      letterSpacing="1px"
-                      borderRadius="0px 4px 4px 0px"
-                      borderWidth="0px"
-                      isActive={cumulativeChartScale === 'log'}
-                      onClick={() => setCumulativeChartScale('log')}
-                    >
-                      {t('logarithmic')}
-                    </Button>
-                  </ButtonGroup>
-                </Flex>
-              </Flex>
-
+              <ButtonGroup
+                spacing={0}
+                alignSelf="center"
+                display="flex"
+                justifyContent="center"
+                marginTop="-15px"
+              >
+                <Button
+                  size="xs"
+                  fontFamily="Space Grotesk Regular"
+                  px={3}
+                  letterSpacing="1px"
+                  borderRadius="4px 0px 0px 4px"
+                  borderWidth="0px"
+                  isActive={cumulativeChartScale === 'linear'}
+                  onClick={() => setCumulativeChartScale('linear')}
+                >
+                  {t('linear')}
+                </Button>
+                <Button
+                  size="xs"
+                  fontFamily="Space Grotesk Regular"
+                  px={3}
+                  letterSpacing="1px"
+                  borderRadius="0px 4px 4px 0px"
+                  borderWidth="0px"
+                  isActive={cumulativeChartScale === 'log'}
+                  onClick={() => setCumulativeChartScale('log')}
+                >
+                  {t('logarithmic')}
+                </Button>
+              </ButtonGroup>
               <ResponsiveContainer width={'100%'} height={380}>
                 <ComposedChart
                   data={
@@ -474,7 +484,10 @@ const Index: NextPage<KoronaData> = ({ confirmed, deaths, recovered }) => {
                   <YAxis
                     scale={cumulativeChartScale}
                     dataKey="infections"
-                    domain={[cumulativeChartScale === 'log' ? 1 : 0, dataMaxValue + 10]}
+                    domain={[
+                      cumulativeChartScale === 'log' ? 1 : 0,
+                      dataMaxValue + 10
+                    ]}
                     unit={' ' + t('person')}
                     tick={{ fontSize: 12 }}
                     name={t('cases')}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -139,12 +139,12 @@ const Index: NextPage<KoronaData> = ({
   recovered: allRecovered
 }) => {
   const [selectedHealthCareDistrict, selectHealthCareDistrict] = useState<
-    string | null
-  >(null);
+    string
+  >('all');
   const districtFilter = (item: BaseItem) =>
-    selectedHealthCareDistrict
-      ? item.healthCareDistrict === selectedHealthCareDistrict
-      : true;
+    selectedHealthCareDistrict === 'all'
+      ? true
+      : item.healthCareDistrict === selectedHealthCareDistrict;
   const confirmed = allConfirmed.filter(districtFilter);
   const deaths = allDeaths.filter(districtFilter);
   const recovered = allRecovered.filter(districtFilter);
@@ -216,6 +216,21 @@ const Index: NextPage<KoronaData> = ({
     .reverse();
 
   const { t } = useContext(UserContext);
+
+  const humanizeHealthcareDistrict = (district: string) => {
+    if (district === 'all') {
+      return t('All healthcare districts');
+    } else if (district === 'unknown') {
+      return t('Unknown');
+    } else {
+      return district;
+    }
+  };
+
+  const humanizedHealthCareDistrict = humanizeHealthcareDistrict(
+    selectedHealthCareDistrict
+  );
+
   return (
     <Layout>
       <Head>
@@ -299,10 +314,15 @@ const Index: NextPage<KoronaData> = ({
         >
           <Box width={['100%', '100%', 1 / 3, 1 / 3]} p={3}>
             <Select
-              placeholder={t('healthcare district')}
               value={selectedHealthCareDistrict ?? undefined}
               onChange={event => selectHealthCareDistrict(event.target.value)}
             >
+              <option key={'all'} value={'all'}>
+                {t('All healthcare districts')}
+              </option>
+              <option key={'unknown'} value={'unknown'}>
+                {t('Unknown')}
+              </option>
               {healtCareDistricts.map(healthcareDistrict => (
                 <option
                   key={healthcareDistrict.name}
@@ -310,6 +330,7 @@ const Index: NextPage<KoronaData> = ({
                 >
                   {healthcareDistrict.name}
                 </option>
+              ))}
               ))}
             </Select>
           </Box>
@@ -324,7 +345,7 @@ const Index: NextPage<KoronaData> = ({
         >
           <Box width={['100%', '100%', 1 / 3, 1 / 3]} p={3}>
             <Block
-              title={t('cases') + ` (${selectedHealthCareDistrict})`}
+              title={t('cases') + ` (${humanizedHealthCareDistrict})`}
               textAlign="center"
               extraInfo={`${t('New cases today')} ${infectionsToday} ${t(
                 'person'
@@ -344,7 +365,7 @@ const Index: NextPage<KoronaData> = ({
           </Box>
           <Box width={['100%', '100%', 1 / 3, 1 / 3]} p={3}>
             <Block
-              title={t('deaths') + ` (${selectedHealthCareDistrict})`}
+              title={t('deaths') + ` (${humanizedHealthCareDistrict})`}
               footer={
                 latestDeath
                   ? `${t('last death')} ${latestDeath} (${latestDeathDistrict})`
@@ -356,7 +377,7 @@ const Index: NextPage<KoronaData> = ({
           </Box>
           <Box width={['100%', '100%', 1 / 3, 1 / 3]} p={3}>
             <Block
-              title={t('recovered') + ` (${selectedHealthCareDistrict})`}
+              title={t('recovered') + ` (${humanizedHealthCareDistrict})`}
               footer={
                 latestRecovered
                   ? `${t(
@@ -371,7 +392,9 @@ const Index: NextPage<KoronaData> = ({
 
           <Box width={['100%']} p={3}>
             <Block
-              title={t('accumulated change')  + ` (${selectedHealthCareDistrict})`}
+              title={
+                t('accumulated change') + ` (${humanizedHealthCareDistrict})`
+              }
               footer={t('cases recovered and death in past 30 days')}
             >
               <ButtonGroup
@@ -660,7 +683,10 @@ const Index: NextPage<KoronaData> = ({
           </Box>
           <Box width={['100%', '100%', '100%', '100%', 1 / 2]} p={3}>
             <Block
-              title={t('Origin country of the cases') + ` (${selectedHealthCareDistrict})`}
+              title={
+                t('Origin country of the cases') +
+                ` (${humanizedHealthCareDistrict})`
+              }
               footer={t('originCountryFooter')}
             >
               <ResponsiveContainer width={'100%'} height={350}>
@@ -699,7 +725,10 @@ const Index: NextPage<KoronaData> = ({
             </Block>
           </Box>
           <Box width={['100%', '100%', '100%', '100%', 1 / 2]} p={3}>
-            <Block title={t('log') + ` (${selectedHealthCareDistrict})`} footer={t('logFooter')}>
+            <Block
+              title={t('log') + ` (${humanizedHealthCareDistrict})`}
+              footer={t('logFooter')}
+            >
               <Table
                 height={350}
                 data={reversedConfirmed}
@@ -709,7 +738,9 @@ const Index: NextPage<KoronaData> = ({
           </Box>
           <Box width={['100%']} p={3}>
             <Block
-              title={t('infectionNetwork') + ` (${selectedHealthCareDistrict})`}
+              title={
+                t('infectionNetwork') + ` (${humanizedHealthCareDistrict})`
+              }
               footer={t('infectionNetworkFooter')}
             >
               <NetworkGraph data={networkGraphData} />
@@ -731,7 +762,9 @@ Index.getInitialProps = async function() {
   const confirmed = data.confirmed.map((i: Confirmed) => ({
     ...i,
     infectionSourceCountry:
-      i.infectionSourceCountry === '' ? null : i.infectionSourceCountry
+      i.infectionSourceCountry === '' ? null : i.infectionSourceCountry,
+    healthCareDistrict:
+      i.healthCareDistrict === '' ? 'unknown' : i.healthCareDistrict
   }));
   return { ...data, confirmed };
 };

--- a/utils/chartDataHelper.ts
+++ b/utils/chartDataHelper.ts
@@ -74,8 +74,7 @@ export const zerosToNulls = (item: InfectionDevelopmentDataItem) => ({
 export const getTimeSeriesData = (
   confirmed: Confirmed[],
   recovered: Recovered[],
-  deaths: Deaths[],
-  filter: Filter
+  deaths: Deaths[]
 ): {
   infectionDevelopmentData: InfectionDevelopmentDataItem[];
   infectionDevelopmentData30Days: InfectionDevelopmentDataItem[];
@@ -108,14 +107,14 @@ export const getTimeSeriesData = (
       },
       curr
     ) => {
-      const items = sortedData.filter(
-        item => isSameDay(new Date(item.date), curr) && filter(item)
+      const items = sortedData.filter(item =>
+        isSameDay(new Date(item.date), curr)
       );
-      const itemsRecovered = sortedDataRecoverd.filter(
-        item => isSameDay(new Date(item.date), curr) && filter(item)
+      const itemsRecovered = sortedDataRecoverd.filter(item =>
+        isSameDay(new Date(item.date), curr)
       );
-      const itemsDeaths = sortedDataDeaths.filter(
-        item => isSameDay(new Date(item.date), curr) && filter(item)
+      const itemsDeaths = sortedDataDeaths.filter(item =>
+        isSameDay(new Date(item.date), curr)
       );
       acc.deaths = acc.deaths + itemsDeaths.length;
       acc.infections = acc.infections + items.length;
@@ -146,15 +145,10 @@ export const getTimeSeriesData = (
 export const getPredictionData = (
   confirmed: Confirmed[],
   deaths: Deaths[],
-  recovered: Recovered[],
-  filter: Filter
+  recovered: Recovered[]
 ): InfectionDevelopmentDataObj => {
-  const currentData30Days = getTimeSeriesData(
-    confirmed,
-    recovered,
-    deaths,
-    filter
-  ).infectionDevelopmentData30Days;
+  const currentData30Days = getTimeSeriesData(confirmed, recovered, deaths)
+    .infectionDevelopmentData30Days;
 
   const indexes = currentData30Days.map((d, i) => i + 1);
   const infections = currentData30Days.map(d => d.infections);

--- a/utils/translation.ts
+++ b/utils/translation.ts
@@ -50,7 +50,7 @@ const phrases: { [key: string]: { [key: string]: string } } = {
     infectionNetwork: 'Tartuntaverkosto',
     infectionNetworkFooter:
       'Kuvio esittää tartunnat verkostona. Numero on tartunnan järjestysnumero. Mikäli suoraa tartuttajaa ei tiedetä linkitetään tartunta alkuperämaahan. Kuvasta on jätetty pois tartunnat joiden suoraa aiheuttajaa tai alkuperämaata ei ole tiedossa. Suomeen merkatut tartunnat liittyvät suurella todennäköisyydellä muihin tartuntaverkostoihin. Solun väri kertoo maan jossa tartunta on todennäköisesti tapahtunut.',
-    'unknown': 'tuntematon'
+    unknown: 'tuntematon'
   },
   en: {
     language: 'English',
@@ -99,7 +99,7 @@ const phrases: { [key: string]: { [key: string]: string } } = {
     infectionNetwork: 'Infection network graph',
     infectionNetworkFooter:
       'Number is the id of the case. Cases withouth origin are left out.',
-    'unknown': 'unknown'
+    unknown: 'unknown'
   },
   fa: {
     language: 'فارسی',
@@ -145,7 +145,7 @@ const phrases: { [key: string]: { [key: string]: string } } = {
     infectionNetwork: 'Infection network graph',
     infectionNetworkFooter:
       'Number is the id of the case. Cases withouth origin are left out.',
-    'unknown': 'ناشناخته'
+    unknown: 'ناشناخته'
   }
 };
 

--- a/utils/translation.ts
+++ b/utils/translation.ts
@@ -17,6 +17,8 @@ const phrases: { [key: string]: { [key: string]: string } } = {
     'last death': 'Viimeisin kuolema',
     'accumulated change': 'Kumulatiivinen kehitys (30 pv)',
     'healthcare district': 'Sairaanhoitopiiri',
+    Unknown: 'Ei julkistettu',
+    'All healthcare districts': 'Kaikki sairaanhoitopiirit',
     'cases recovered and death in past 30 days':
       'Tartuntojen, parantuneiden ja menehtyneiden kumulatiivinen kehitys viimeisen 30 päivän aikana',
     linear: 'Lineaarinen',

--- a/utils/translation.ts
+++ b/utils/translation.ts
@@ -17,7 +17,6 @@ const phrases: { [key: string]: { [key: string]: string } } = {
     'last death': 'Viimeisin kuolema',
     'accumulated change': 'Kumulatiivinen kehitys (30 pv)',
     'healthcare district': 'Sairaanhoitopiiri',
-    Unknown: 'Ei julkistettu',
     'All healthcare districts': 'Kaikki sairaanhoitopiirit',
     'cases recovered and death in past 30 days':
       'Tartuntojen, parantuneiden ja menehtyneiden kumulatiivinen kehitys viimeisen 30 päivän aikana',


### PR DESCRIPTION
Tämä laajentaa kyseisen valinnan kaikkiin graafeihin, paitsi "Tartunnat sairaanhoitopiireittäin" ja "Tartunnat sairaanhoitopiireittäin / sairaanhoitopiirin koko" graafeihin. 

<img width="1500" alt="Screenshot 2020-03-22 at 19 49 34" src="https://user-images.githubusercontent.com/2647016/77256349-58cd1f00-6c76-11ea-9d8c-e8f6951a7bdf.png">

Tämä PR lisää myös:
- paremman tuen kaikille sairaanhoitopiireille
- paremman tuen tuntemattomille sairaanhoitopiireille
- paremman hanskauksen 0 arvoille(Tämä PR alunperin: https://github.com/valstu/korona-info/pull/27 )