### PR TITLE
Healthcare district bubble chart

### DIFF
--- a/components/BubbleChart.tsx
+++ b/components/BubbleChart.tsx
@@ -1,0 +1,122 @@
+import { useState, useContext } from 'react';
+
+import {
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  ScatterChart,
+  ZAxis,
+  Scatter
+} from 'recharts';
+import { Box, Button, ButtonGroup } from '@chakra-ui/core';
+
+import _ from 'lodash';
+
+import Block from '../components/Block';
+import { UserContext } from '../pages/_app';
+import { InfectionDevelopmentDataItem } from '../utils/chartDataHelper';
+import { GroupedData } from '../pages';
+
+const BubbleChart = ({ data }: { data: GroupedData }) => {
+  const [chartScale, setChartScale] = useState<'cumulative' | 'daily'>('daily');
+  const { t } = useContext(UserContext);
+  return (
+    <Box width={['100%']} p={3}>
+      <Block
+        title={t('accumulation by healthcare district')}
+        footer={t('cases recovered and death in past 30 days')}
+      >
+        <ButtonGroup
+          spacing={0}
+          alignSelf="center"
+          display="flex"
+          justifyContent="center"
+          marginTop="-15px"
+        >
+          <Button
+            size="xs"
+            fontFamily="Space Grotesk Regular"
+            px={3}
+            letterSpacing="1px"
+            borderRadius="4px 0px 0px 4px"
+            borderWidth="0px"
+            isActive={chartScale === 'cumulative'}
+            onClick={() => setChartScale('cumulative')}
+          >
+            {t('cumulative')}
+          </Button>
+          <Button
+            size="xs"
+            fontFamily="Space Grotesk Regular"
+            px={3}
+            letterSpacing="1px"
+            borderRadius="0px 4px 4px 0px"
+            borderWidth="0px"
+            isActive={chartScale === 'daily'}
+            onClick={() => setChartScale('daily')}
+          >
+            {t('daily')}
+          </Button>
+        </ButtonGroup>
+        <Box p={5}>
+          {_.map(data, (district, key) => {
+            return (
+              <ResponsiveContainer key={key} width={'60%'} height={42}>
+                <ScatterChart
+                  key={key}
+                  margin={{
+                    top: 0,
+                    right: 0,
+                    bottom: 0,
+                    left: 0
+                  }}
+                >
+                  <XAxis
+                    type="category"
+                    dataKey="date"
+                    interval={0}
+                    tick={false}
+                    axisLine={false}
+                    tickLine={false}
+                  />
+                  <YAxis
+                    type="number"
+                    dataKey="y"
+                    name={key}
+                    height={10}
+                    tick={false}
+                    tickLine={false}
+                    axisLine={false}
+                    label={{ value: key, position: 'insideLeft' }}
+                  />
+                  <ZAxis
+                    type="number"
+                    dataKey={
+                      chartScale === 'daily' ? 'infectionsDaily' : 'infections'
+                    }
+                    range={[0, 350]}
+                    // @ts-ignore
+                    domain={[0, chartScale === 'daily' ? 50 : 350]}
+                  />
+                  <Tooltip cursor={false} wrapperStyle={{ zIndex: 100 }} />
+                  <Scatter
+                    data={district.timeSeries.infectionDevelopmentData30Days.map(
+                      (data: InfectionDevelopmentDataItem) => ({
+                        ...data,
+                        y: 0
+                      })
+                    )}
+                    fill="#f3858d"
+                  />
+                </ScatterChart>
+              </ResponsiveContainer>
+            );
+          })}
+        </Box>
+      </Block>
+    </Box>
+  );
+};
+
+export default BubbleChart;

--- a/components/BubbleChart.tsx
+++ b/components/BubbleChart.tsx
@@ -62,13 +62,12 @@ const BubbleChart = ({ data }: { data: GroupedData }) => {
         <Box p={5}>
           {_.map(data, (district, key) => {
             return (
-              <ResponsiveContainer key={key} width={'100%'} height={42}>
+              <ResponsiveContainer key={key} width={'100%'} height={25}>
                 <ScatterChart
-                  key={key}
                   margin={{
                     top: 0,
                     right: 0,
-                    bottom: 0,
+                    bottom: -17,
                     left: 0
                   }}
                 >
@@ -84,7 +83,8 @@ const BubbleChart = ({ data }: { data: GroupedData }) => {
                     type="number"
                     dataKey="y"
                     name={key}
-                    height={10}
+                    height={0}
+                    interval={0}
                     tick={false}
                     tickLine={false}
                     axisLine={false}

--- a/components/BubbleChart.tsx
+++ b/components/BubbleChart.tsx
@@ -17,6 +17,7 @@ import Block from '../components/Block';
 import { UserContext } from '../pages/_app';
 import { InfectionDevelopmentDataItem } from '../utils/chartDataHelper';
 import { GroupedData } from '../pages';
+import { format, utcToZonedTime } from 'date-fns-tz';
 
 const BubbleChart = ({ data }: { data: GroupedData }) => {
   const [chartScale, setChartScale] = useState<'cumulative' | 'daily'>('daily');
@@ -92,6 +93,7 @@ const BubbleChart = ({ data }: { data: GroupedData }) => {
                   />
                   <ZAxis
                     type="number"
+                    name="infections"
                     dataKey={
                       chartScale === 'daily' ? 'infectionsDaily' : 'infections'
                     }
@@ -99,7 +101,23 @@ const BubbleChart = ({ data }: { data: GroupedData }) => {
                     // @ts-ignore
                     domain={[0, chartScale === 'daily' ? 50 : 350]}
                   />
-                  <Tooltip cursor={false} wrapperStyle={{ zIndex: 100 }} />
+                  <Tooltip
+                    cursor={false}
+                    wrapperStyle={{ zIndex: 100 }}
+                    formatter={(value, name, props) => {
+                      if (name === 'date') {
+                        return format(
+                          // @ts-ignore
+                          utcToZonedTime(value, 'Europe/Helsinki'),
+                          'd.M.yyyy'
+                        );
+                      } else if (name === 'infections') {
+                        return [value, name];
+                      } else {
+                        return [];
+                      }
+                    }}
+                  />
                   <Scatter
                     data={district.timeSeries.infectionDevelopmentData30Days.map(
                       (data: InfectionDevelopmentDataItem) => ({

--- a/components/BubbleChart.tsx
+++ b/components/BubbleChart.tsx
@@ -26,7 +26,6 @@ const BubbleChart = ({ data }: { data: GroupedData }) => {
     <Box width={['100%']} p={3}>
       <Block
         title={t('accumulation by healthcare district')}
-        footer={t('cases recovered and death in past 30 days')}
       >
         <ButtonGroup
           spacing={0}

--- a/components/BubbleChart.tsx
+++ b/components/BubbleChart.tsx
@@ -23,7 +23,7 @@ const BubbleChart = ({ data }: { data: GroupedData }) => {
   const [chartScale, setChartScale] = useState<'cumulative' | 'daily'>('daily');
   const { t } = useContext(UserContext);
   return (
-    <Box width={['100%']} p={3}>
+    <Box width={['100%', '100%', '100%', '100%', 1 / 2]} p={3}>
       <Block
         title={t('accumulation by healthcare district')}
       >
@@ -62,7 +62,7 @@ const BubbleChart = ({ data }: { data: GroupedData }) => {
         <Box p={5}>
           {_.map(data, (district, key) => {
             return (
-              <ResponsiveContainer key={key} width={'60%'} height={42}>
+              <ResponsiveContainer key={key} width={'100%'} height={42}>
                 <ScatterChart
                   key={key}
                   margin={{

--- a/components/BubbleChart.tsx
+++ b/components/BubbleChart.tsx
@@ -104,6 +104,7 @@ const BubbleChart = ({ data }: { data: GroupedData }) => {
                   <Tooltip
                     cursor={false}
                     wrapperStyle={{ zIndex: 100 }}
+                    isAnimationActive={false}
                     formatter={(value, name, props) => {
                       if (name === 'date') {
                         return format(

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -7,7 +7,7 @@ const customTheme = {
     ...theme.fonts,
     heading: 'Space Grotesk Regular, sans-serif',
     body: 'Space Grotesk Regular, sans-serif',
-    mono: 'Space Mono, Menlo, monospace',
+    mono: 'Space Mono, Menlo, monospace'
   }
 };
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -34,6 +34,8 @@ import {
   Select
 } from '@chakra-ui/core';
 
+import _ from 'lodash';
+
 import Layout from '../components/Layout';
 import StatBlock from '../components/StatBlock';
 import Block from '../components/Block';
@@ -53,14 +55,11 @@ import {
   colors,
   getInfectionsToday,
   healtCareDistricts,
-  zerosToNulls
+  zerosToNulls,
+  InfectionDevelopmentDataItem,
+  TimeSeriesData
 } from '../utils/chartDataHelper';
-
-export interface KoronaData {
-  confirmed: Confirmed[];
-  recovered: Recovered[];
-  deaths: any[];
-}
+import BubbleChart from '../components/BubbleChart';
 
 interface BaseItem {
   healthCareDistrict: string;
@@ -89,6 +88,15 @@ export enum InfectionSourceEnum {
   RelatedToEarlier = 'related to earlier',
   Unknown = 'unknown'
 }
+
+export type GroupedData = {
+  [key: string]: {
+    confirmed: Confirmed[];
+    deaths: Deaths[];
+    recovered: Recovered[];
+    timeSeries: TimeSeriesData;
+  };
+};
 
 const CustomizedAxisTick: React.FC<any> = props => {
   const { x, y, stroke, payload, isDate } = props;
@@ -133,27 +141,29 @@ const ConditionallyRender: React.FC<ConditionallyRenderProps> = props => {
   return props.children as React.ReactElement;
 };
 
-const Index: NextPage<KoronaData> = ({
-  confirmed: allConfirmed,
-  deaths: allDeaths,
-  recovered: allRecovered
+const Index: NextPage<{ groupedCoronaData: GroupedData }> = ({
+  groupedCoronaData
+}: {
+  groupedCoronaData: GroupedData;
 }) => {
   const [selectedHealthCareDistrict, selectHealthCareDistrict] = useState<
     string
   >('all');
-  const districtFilter = (item: BaseItem) =>
-    selectedHealthCareDistrict === 'all'
-      ? true
-      : item.healthCareDistrict === selectedHealthCareDistrict;
-  const confirmed = allConfirmed.filter(districtFilter);
-  const deaths = allDeaths.filter(districtFilter);
-  const recovered = allRecovered.filter(districtFilter);
+  const confirmed = groupedCoronaData[selectedHealthCareDistrict].confirmed;
+  const deaths = groupedCoronaData[selectedHealthCareDistrict].deaths;
+  const recovered = groupedCoronaData[selectedHealthCareDistrict].recovered;
+  const allConfirmed = groupedCoronaData.all.confirmed;
 
-  const latestInfection = confirmed.length ? format(
-    utcToZonedTime(new Date(confirmed[confirmed.length - 1].date), timeZone),
-    'dd.MM.yyyy - HH:mm',
-    { timeZone }
-  ) : null;
+  const latestInfection = confirmed.length
+    ? format(
+        utcToZonedTime(
+          new Date(confirmed[confirmed.length - 1].date),
+          timeZone
+        ),
+        'dd.MM.yyyy - HH:mm',
+        { timeZone }
+      )
+    : null;
   const latestInfectionDistrict =
     confirmed[confirmed.length - 1]?.healthCareDistrict;
   const latestDeath = deaths.length
@@ -189,7 +199,7 @@ const Index: NextPage<KoronaData> = ({
   const {
     infectionDevelopmentData,
     infectionDevelopmentData30Days
-  } = getTimeSeriesData(confirmed, recovered, deaths);
+  } = groupedCoronaData[selectedHealthCareDistrict].timeSeries;
   const maxValues =
     infectionDevelopmentData30Days[infectionDevelopmentData30Days.length - 1];
   const dataMaxValue = Math.max(
@@ -219,7 +229,12 @@ const Index: NextPage<KoronaData> = ({
   };
 
   const reversedConfirmed = confirmed
-    .map((i, index) => ({ index: index + 1, ...i, healthCareDistrict: humanizeHealthcareDistrict(i.healthCareDistrict) }))
+    // @ts-ignore
+    .map((i, index) => ({
+      index: index + 1,
+      ...i,
+      healthCareDistrict: humanizeHealthcareDistrict(i.healthCareDistrict)
+    }))
     .reverse();
 
   const humanizedHealthCareDistrict = humanizeHealthcareDistrict(
@@ -347,7 +362,9 @@ const Index: NextPage<KoronaData> = ({
               )}`}
               footer={`${t(
                 'latest case'
-              )} ${latestInfection} (${humanizeHealthcareDistrict(latestInfectionDistrict)})`}
+              )} ${latestInfection} (${humanizeHealthcareDistrict(
+                latestInfectionDistrict
+              )})`}
             >
               <StatBlock
                 count={confirmed.length}
@@ -362,7 +379,11 @@ const Index: NextPage<KoronaData> = ({
               title={t('deaths') + ` (${humanizedHealthCareDistrict})`}
               footer={
                 latestDeath
-                  ? `${t('last death')} ${latestDeath} (${humanizeHealthcareDistrict(latestDeathDistrict!)})`
+                  ? `${t(
+                      'last death'
+                    )} ${latestDeath} (${humanizeHealthcareDistrict(
+                      latestDeathDistrict!
+                    )})`
                   : t('no death')
               }
             >
@@ -729,6 +750,7 @@ const Index: NextPage<KoronaData> = ({
               />
             </Block>
           </Box>
+          <BubbleChart data={groupedCoronaData} />
           <Box width={['100%']} p={3}>
             <Block
               title={
@@ -752,14 +774,41 @@ Index.getInitialProps = async function() {
     'https://w3qa5ydb4l.execute-api.eu-west-1.amazonaws.com/prod/finnishCoronaData'
   );
   const data = await res.json();
-  const confirmed = data.confirmed.map((i: Confirmed) => ({
-    ...i,
-    infectionSourceCountry:
-      i.infectionSourceCountry === '' ? null : i.infectionSourceCountry,
-    healthCareDistrict:
-      i.healthCareDistrict ? i.healthCareDistrict : 'unknown' // there are empty strings and nulls
-  }));
-  return { ...data, confirmed };
+
+  const groupedConfirmed = _.groupBy(
+    data.confirmed,
+    data => data.healthCareDistrict
+  );
+  const groupedDeaths = _.groupBy(data.deaths, data => data.healthCareDistrict);
+  const groupedRecovered = _.groupBy(
+    data.recovered,
+    data => data.healthCareDistrict
+  );
+  const keys = Object.keys(groupedConfirmed);
+  const result: GroupedData = keys.reduce(
+    (previous, key) => {
+      return {
+        ...previous,
+        [key === 'null' ? 'unknown' : key]: {
+          confirmed: groupedConfirmed[key] ?? [],
+          recovered: groupedRecovered[key] ?? [],
+          deaths: groupedDeaths[key] ?? [],
+          timeSeries: getTimeSeriesData(
+            groupedConfirmed[key],
+            groupedRecovered[key],
+            groupedDeaths[key]
+          )
+        }
+      };
+    },
+    {
+      all: {
+        ...data,
+        timeSeries: getTimeSeriesData(data.confirmed, data.deaths, data.deaths)
+      }
+    }
+  );
+  return { groupedCoronaData: result };
 };
 
 export default Index;

--- a/utils/translation.ts
+++ b/utils/translation.ts
@@ -16,12 +16,16 @@ const phrases: { [key: string]: { [key: string]: string } } = {
     'latest case': 'Viimeisin varmennettu tapaus',
     'last death': 'Viimeisin kuolema',
     'accumulated change': 'Kumulatiivinen kehitys (30 pv)',
+    'accumulation by healthcare district':
+      'Sairaanhoitopiirikohtainen kehitys  (30 pv)',
     'healthcare district': 'Sairaanhoitopiiri',
     'All healthcare districts': 'Kaikki sairaanhoitopiirit',
     'cases recovered and death in past 30 days':
       'Varmennettujen tapausten, parantuneiden ja menehtyneiden kumulatiivinen kehitys viimeisen 30 päivän aikana',
     linear: 'Lineaarinen',
     logarithmic: 'Logaritminen',
+    cumulative: 'Kumulatiivinen',
+    daily: 'Päivittäinen',
     'total cases': 'Varmennetut tapaukset yht.',
     'total recovered': 'Parantuneet yht.',
     'recoveredNotice': 'Sisältää vain tapaukset joista HS on saanut tiedon, määrä on todellisuudessa suurempi',
@@ -69,12 +73,16 @@ const phrases: { [key: string]: { [key: string]: string } } = {
     'latest case': 'Latest case',
     'last death': 'Latest death',
     'accumulated change': 'Accumuluated change (30 days)',
+    'accumulation by healthcare district':
+      'Accumuluated change by healthcare district (30 days)',
     'healthcare district': 'Healthcare district',
     'All healthcare districts': 'All healthcare districts',
     'cases recovered and death in past 30 days':
       'Cases, recovered cases, and deaths in the past 30 days',
     linear: 'Linear',
     logarithmic: 'Logarithmic',
+    cumulative: 'Cumulative',
+    daily: 'Daily',
     'total cases': 'Total cases',
     'total recovered': 'Total recovered',
     'recoveredNotice': 'Includes only recovered cases that HS has infomation about, true amount is higher.',
@@ -92,7 +100,7 @@ const phrases: { [key: string]: { [key: string]: string } } = {
       'Information on this page is based on open data provided by ',
     'open data': 'Helsingin Sanomat.',
     'HS has gathered these data from':
-     'Helsingin Sanomat has gathered the information from multiple public sources: press conferences, other media and interviews. Data is updated whenever new information about the cases appear. More information below:',
+      'Helsingin Sanomat has gathered the information from multiple public sources: press conferences, other media and interviews. Data is updated whenever new information about the cases appear. More information below:',
     'What is corona virus': 'What is corona virus (in finnish)',
     'Corona virus prevention tips': 'Corona virus prevention tips (in finnish)',
     infectionsPerDisrictAndSize:


### PR DESCRIPTION
Chart to show daily situation in individual health care districts at one glance. Bot cumulative and daily infections are selectable.

Also:
- Refactors data handling so that most of the data is calculated before hand since the new chart needs it in grouped form
- Fine tunes cumulative chart so that it shows last 30 days for all the health care districts even though some district wouldn't have 30days worth of data. This was necessary for making bubble chart to work as well.

Potential further improvements: Map of Finland to the right side showing daily situation in each healthcare district.

<img width="1111" alt="Screenshot 2020-03-26 at 23 46 17" src="https://user-images.githubusercontent.com/2647016/77700252-7b37a300-6fbc-11ea-94e9-4dd2d05b684b.png">
<img width="987" alt="Screenshot 2020-03-26 at 23 46 25" src="https://user-images.githubusercontent.com/2647016/77700259-7d99fd00-6fbc-11ea-99ad-6d242deec854.png">

<img width="1006" alt="Screenshot 2020-03-27 at 0 36 47" src="https://user-images.githubusercontent.com/2647016/77703267-15024e80-6fc3-11ea-87dd-311cdc2672b5.png">
