### PR TITLE
Remove origin country and ID from the infection log

### DIFF
--- a/components/TableColumns.ts
+++ b/components/TableColumns.ts
@@ -9,13 +9,6 @@ export const infectionColumns = [
     }
   },
   {
-    Header: 'Id',
-    accessor: 'id',
-    Cell: ({ cell }: any) => {
-      return `#0${cell.value}`;
-    }
-  },
-  {
     Header: 'Päiväys',
     accessor: 'date',
     minWidth: '20%',
@@ -25,22 +18,5 @@ export const infectionColumns = [
   {
     Header: 'Sair.hoitopiiri',
     accessor: 'healthCareDistrict'
-  },
-  {
-    Header: 'Maa',
-    accessor: 'infectionSourceCountry'
-  },
-  {
-    Header: 'Tartunnan lähde',
-    accessor: 'infectionSource',
-    Cell: ({ cell: { value } }: any) => {
-      if (value === 'unknown') {
-        return 'Ei tiedossa';
-      }
-      if (value === 'related to earlier') {
-        return 'Liittyy aiempaan';
-      }
-      return `#0${value}`;
-    }
   }
 ];

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -691,51 +691,6 @@ const Index: NextPage<{ groupedCoronaData: GroupedData }> = ({
             </Box>
             <Box width={['100%', '100%', '100%', '100%', 1 / 2]} p={3}>
               <Block
-                title={
-                  t('Origin country of the cases') +
-                  ` (${humanizedHealthCareDistrict})`
-                }
-                footer={t('originCountryFooter')}
-              >
-                <ResponsiveContainer width={'100%'} height={350}>
-                  <BarChart
-                    
-                    data={infectionsBySourceCountry}
-                    margin={{
-                      top: 20,
-                      right: 30,
-                      left: 0,
-                      bottom: 85
-                    }}
-                  >
-                    <XAxis
-                      interval={0}
-                      dataKey="name"
-                      tick={<CustomizedAxisTick />}
-                    />
-                    <YAxis
-                      unit={' ' + t('person')}
-                      dataKey="infections"
-                      tick={{ fontSize: 12 }}
-                    />
-                    <Tooltip />
-                    <Bar
-                      isAnimationActive={false}
-                      dataKey="infections"
-                      name="Tartunnat"
-                      unit={' ' + t('person')}
-                    >
-                      {areas.map((area, index) => (
-                        <Cell key={area} fill={colors[index % colors.length]} />
-                      ))}
-                      <LabelList dataKey="infections" position="top" />
-                    </Bar>
-                  </BarChart>
-                </ResponsiveContainer>
-              </Block>
-            </Box>
-            <Box width={['100%', '100%', '100%', '100%', 1 / 2]} p={3}>
-              <Block
                 title={t('log') + ` (${humanizedHealthCareDistrict})`}
                 footer={t('logFooter')}
               >


### PR DESCRIPTION
The new `v2` API is based on the THL data which doesn't provide an origin country and the ID was changed from a running number to a combination of the fields. This PR removes those fields from the UI.

See https://github.com/HS-Datadesk/koronavirus-avoindata/pull/59

Before:
![image](https://user-images.githubusercontent.com/7641760/78266302-483a6580-750e-11ea-9111-29e430b4e30c.png)

After:

![image](https://user-images.githubusercontent.com/7641760/78266364-5c7e6280-750e-11ea-9774-f82117f100b8.png)


Signed-off-by: petetnt <pete.a.nykanen@gmail.com>