### PR TITLE
Fix district specific death counts being always zero

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -59,7 +59,8 @@ import {
   healtCareDistricts,
   zerosToNulls,
   InfectionDevelopmentDataItem,
-  TimeSeriesData
+  TimeSeriesData,
+  getHealthCareDistrictByHealthCareArea
 } from '../utils/chartDataHelper';
 import BubbleChart from '../components/BubbleChart';
 
@@ -819,6 +820,12 @@ Index.getInitialProps = async function () {
     .sort(
       (a: HospitalData, b: HospitalData) => a.date.getTime() - b.date.getTime()
     );
+
+  generalData.deaths.forEach((item: any) => {
+    if (!item.healthCareDistrict) {
+      item.healthCareDistrict = getHealthCareDistrictByHealthCareArea(item.area)
+    }
+  });
 
   generalData.confirmed = sortBy(generalData.confirmed, 'date')
   generalData.deaths = sortBy(generalData.deaths, 'date')

--- a/utils/chartDataHelper.ts
+++ b/utils/chartDataHelper.ts
@@ -46,6 +46,33 @@ export const healtCareDistricts = [
   { name: 'Vaasa', people: 169741 }
 ];
 
+export const healthCareAreaToDistrictMap : { [key:string]:string; } = {
+  'HYKS': 'HUS',
+  '0001': 'Etelä-Karjala',
+  '0002': 'Kymenlaakso',
+  '0003': 'Päijät-Häme',
+  'KYS': 'Pohjois-Savo',
+  '0005': 'Etelä-Savo',
+  '0006': 'Itä-Savo',
+  '0007': 'Keski-Suomi',
+  '0008': 'Pohjois-Karjala',
+  'OYS': 'Pohjois-Pohjanmaa',
+  '0010': 'Kainuu',
+  '0011': 'Keski-Pohjanmaa',
+  '0012': 'Lappi',
+  '0013': 'Länsi-Pohja',
+  'TAYS': 'Pirkanmaa',
+  '0015': 'Etelä-Pohjanmaa',
+  '0016': 'Kanta-Häme',
+  'TYKS': 'Varsinais-Suomi',
+  '0018': 'Satakunta',
+  '0019': 'Vaasa'
+};
+
+export const getHealthCareDistrictByHealthCareArea = (area: string): string | null => {
+  return healthCareAreaToDistrictMap[area] || null
+};
+
 const peopleTotal = healtCareDistricts.reduce(
   (acc, curr) => curr.people + acc,
   0


### PR DESCRIPTION
Hey, and thanks for making the app!

This PR is related to issue #62 

I implemented a simple lookup table for providing hospital -> health care district info and wired it to the initialProps parsing. My idea was to use the mapping table to fill in the missing health care district in the source data if the district was missing. I tried to follow you code conventions as much as possible, hopefully close enough. =)

The mapping table (and a simple function to fetch data from it) is implemented in the chartDataHelper.ts and it is used in index.ts while parsing initial props. I filled in all the hospitals the API had reported data on, and left the other ones with placeholder mappings, so we could complete the mapping table as we see new hospitals popping up in the API. Not sure if they would have a complete list of hospitals somewhere, but at least I could not find those on quick glance.

Anyways, sorry for not notifying about the PR first, just had some extra time on my hands (quarantine FTW) and decided to drop you this. Feel free to use it if you like, or drop me a note if you would like to change something. 

Cheers,
Juha   
